### PR TITLE
Make file/folder dialogs automatically come to foreground on Windows

### DIFF
--- a/AssetRipper.NativeDialogs/OpenFileDialog.cs
+++ b/AssetRipper.NativeDialogs/OpenFileDialog.cs
@@ -40,7 +40,7 @@ public static class OpenFileDialog
 		{
 			OPENFILENAMEW ofn = default;
 			ofn.lStructSize = (uint)Unsafe.SizeOf<OPENFILENAMEW>();
-			ofn.hwndOwner = default; // No owner window.
+			ofn.hwndOwner = Windows.GetConsoleWindow(); // Use console window as owner to ensure dialog comes to foreground
 			ofn.lpstrFile = bufferPtr;
 			ofn.nMaxFile = (uint)buffer.Length;
 			ofn.lpstrFilter = filterPtr;
@@ -119,7 +119,7 @@ public static class OpenFileDialog
 		{
 			OPENFILENAMEW ofn = default;
 			ofn.lStructSize = (uint)Unsafe.SizeOf<OPENFILENAMEW>();
-			ofn.hwndOwner = default; // No owner window.
+			ofn.hwndOwner = Windows.GetConsoleWindow(); // Use console window as owner to ensure dialog comes to foreground
 			ofn.lpstrFile = bufferPtr;
 			ofn.nMaxFile = (uint)buffer.Length;
 			ofn.lpstrFilter = filterPtr;

--- a/AssetRipper.NativeDialogs/OpenFolderDialog.cs
+++ b/AssetRipper.NativeDialogs/OpenFolderDialog.cs
@@ -90,8 +90,9 @@ public static class OpenFolderDialog
 		pFileDialog->GetOptions(&dwOptions);
 		pFileDialog->SetOptions(dwOptions | (uint)FILEOPENDIALOGOPTIONS.FOS_PICKFOLDERS | (uint)FILEOPENDIALOGOPTIONS.FOS_FORCEFILESYSTEM);
 
-		// Show the dialog
-		hr = pFileDialog->Show(default);
+		// Show the dialog with console window as owner to ensure it comes to foreground
+		HWND hwndOwner = Windows.GetConsoleWindow();
+		hr = pFileDialog->Show(hwndOwner);
 		if (Windows.SUCCEEDED(hr))
 		{
 			IShellItem* pItem;
@@ -221,8 +222,9 @@ public static class OpenFolderDialog
 
 		string[]? result = null;
 
-		// Show the dialog
-		hr = pFileDialog->Show(default);
+		// Show the dialog with console window as owner to ensure it comes to foreground
+		HWND hwndOwner = Windows.GetConsoleWindow();
+		hr = pFileDialog->Show(hwndOwner);
 		if (Windows.SUCCEEDED(hr))
 		{
 			IShellItemArray* pItemArray;

--- a/AssetRipper.NativeDialogs/SaveFileDialog.cs
+++ b/AssetRipper.NativeDialogs/SaveFileDialog.cs
@@ -42,7 +42,7 @@ public static class SaveFileDialog
 		{
 			OPENFILENAMEW ofn = default;
 			ofn.lStructSize = (uint)Unsafe.SizeOf<OPENFILENAMEW>();
-			ofn.hwndOwner = default; // No owner window.
+			ofn.hwndOwner = Windows.GetConsoleWindow(); // Use console window as owner to ensure dialog comes to foreground
 			ofn.lpstrFile = bufferPtr;
 			ofn.nMaxFile = (uint)buffer.Length;
 			ofn.lpstrFilter = filterPtr;


### PR DESCRIPTION
Fixes the issue where file and folder dialogs would not automatically come to the foreground when opened, requiring users to manually click on them in the taskbar.

## Changes
- Modified `OpenFileDialog.cs`, `SaveFileDialog.cs`, and `OpenFolderDialog.cs` to use `Windows.GetConsoleWindow()` as the owner window handle instead of `default` (null)
- This associates the dialogs with the console window, ensuring Windows brings them to the foreground automatically